### PR TITLE
Default to provided appName

### DIFF
--- a/appstorereviews.js
+++ b/appstorereviews.js
@@ -17,6 +17,7 @@ exports.startReview = function (config) {
 
         const appInformation = {};
         appInformation.region = region;
+        appInformation.appName = config.appName;
 
         exports.fetchAppStoreReviews(config, appInformation, function (entries) {
             var reviewLength = entries.length;

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports.start = function start(config) {
             channel: app.channel || config.channel,
             publisherKey: app.publisherKey,
             appId: app.appId,
+            appName: app.appName,
             regions: app.regions
         })
     }


### PR DESCRIPTION
Looks like the Apple app store review feed json no longer contains the
"im:name" property in the entry, so the app name is not available in the
feed. Use a default app name to handle this case.