### PR TITLE
Fix depth of page in appstorereviews.js, fix #31

### DIFF
--- a/appstorereviews.js
+++ b/appstorereviews.js
@@ -116,7 +116,7 @@ exports.fetchAppStoreReviews = function (config, appInformation, callback) {
     var allReviews = [];
     function pageCallback(reviews){
         allReviews = allReviews.concat(reviews);
-        if (reviews.length > 0 && page < 11){
+        if (reviews.length > 0 && page < 10){
             page++;
             fetchAppStoreReviewsByPage(config, appInformation, page, pageCallback);
         } else {


### PR DESCRIPTION
As the original condition was `< 11`, and the following statement is going to plus one page variable,
the max value of page would be 11 in this situation, which is over the maximum: `10`.

When we request the 11th page of the reviews, it'll return http 400 error, with content:
`CustomerReviews RSS page depth is limited to 10`,
which can't be parsed by JSON format properly and causing exception like #31.