### PR TITLE
Update package.json and package-lock.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,12 +42,9 @@
   },
   "dependencies": {
     "android-versions": "^1.4.0",
-    "cheerio": "~1.0.0-rc.3",
     "commander": "^4.0.1",
     "google-play-scraper": "^7.1.1",
     "googleapis": "^45.0.0",
-    "moment": "^2.24.0",
-    "npm": "^6.8.0",
     "request": "^2.88.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,14 +32,6 @@
     "url": "https://github.com/TradeMe/ReviewMe/issues"
   },
   "homepage": "https://github.com/TradeMe/ReviewMe#readme",
-  "devDependencies": {
-    "chai": "4.2.0",
-    "co-mocha": "1.2.2",
-    "forever": "^1.0.0",
-    "mocha": "6.2.2",
-    "sinon": "7.5.0",
-    "sinon-chai": "3.3.0"
-  },
   "dependencies": {
     "android-versions": "^1.4.0",
     "commander": "^4.0.1",


### PR DESCRIPTION
Remove unused `dependencies` & `devDependencies` in `package.json`

This helps reduce the size of `node_modules/`, speed up `npm install` process, and also help reduce unnecessary vulnerabilities warnings, before this change, `npm audit` or `npm install` will tell you that:
> found 39 vulnerabilities (5 **low**, 19 **moderate**, 14 **high**, 1 **critical**) in 14012 scanned packages

it takes 13.5 secs(on my computer) to install, the size of `node_modules/` is about 123MB

After this clean up:
> found 21 vulnerabilities (2 **low**, 19 **moderate**) in 523 scanned packages

it would take only about 3.4 secs(on my computer) to install, the size of `node_modules/` is about 67MB

It's now more easily to be maintained and upgraded in the future.
