### PR TITLE
Update google-play-scraper to 8.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "android-versions": "^1.4.0",
     "commander": "^4.1.1",
-    "google-play-scraper": "^7.1.3",
+    "google-play-scraper": "^8.0.2",
     "googleapis": "^52.1.0",
     "request": "^2.88.0"
   }


### PR DESCRIPTION
google-play-scraper updated to 8.0.2 as it was a bug with `SyntaxError: Unexpected token , in JSON at position 6038`
ref link: https://github.com/facundoolano/google-play-scraper/issues/433