### PR TITLE
Update Docker base image to node.js v14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:14-alpine
 
 ARG ReviewMeVersion=2
 


### PR DESCRIPTION
node.js v10 will be EOL in the next year, I've been running ReviewMe on node.js v14 for a while and looks like the functions are working properly.