### PR TITLE
Allow publisherKey to contain object rather then path to file containing that object

### DIFF
--- a/googleplayreviews.js
+++ b/googleplayreviews.js
@@ -79,10 +79,14 @@ exports.fetchGooglePlayReviews = function (config, appInformation, callback) {
 
     //read publisher json key
     var publisherJson;
-    try {
-        publisherJson = JSON.parse(require('fs').readFileSync(config.publisherKey, 'utf8'));
-    } catch (e) {
-        console.warn(e)
+    if (typeof config.publisherKey === 'object') {
+        publisherJson = config.publisherKey;
+    } else {
+        try {
+            publisherJson = JSON.parse(require('fs').readFileSync(config.publisherKey, 'utf8'));
+        } catch (e) {
+            console.warn(e)
+        }
     }
 
     var jwt;


### PR DESCRIPTION
Hi,

we are using your app inmaybe a bit unexpected manner. We basically don't call your command, instead we reimplement it so it loads all its config from env vars rather then a file.

```
const fs = require('fs');
const reviewme = require('@trademe/reviewme');

const config = {
	slackHook: process.env.SLACK_HOOK_URL,
	verbose: process.env.REVIEWME_VERBOSE === 'yes',
	dryRun: process.env.REVIEWME_DRY_RUN === 'yes',
	interval: parseInt(process.env.REVIEWME_INTERVAL || '300'),
	apps: [],
}

if (process.env.IOS_APP_ID) {
	config.apps.push({
		appId: process.env.IOS_APP_ID,
		regions: false,
	})
}

if (process.env.ANDROID_APP_ID && process.env.ANDROID_KEY_JSON) {
	const keyPath = '/app/android.key.json'
	fs.writeFileSync(keyPath, process.env.ANDROID_KEY_JSON);
	config.apps.push({
		appId: process.env.ANDROID_APP_ID,
		publisherKey: keyPath,
	})
}

reviewme.start(config);
```

with this change I can now do this instead:

```
if (process.env.ANDROID_APP_ID && process.env.ANDROID_KEY_JSON) {
	config.apps.push({
		appId: process.env.ANDROID_APP_ID,
		publisherKey: JSON.parse(process.env.ANDROID_KEY_JSON),
	})
}
```

and so I avoid storing anything (and especially private credentials) in filesystem in a temporary file.

Another use case could be to include the publisherKey json directly in the config.json of the app. Not sure who and why would do this, but why not I guess.