### PR TITLE
Update Docker base image to node.js v18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:18-alpine
 
 ARG ReviewMeVersion=2
 


### PR DESCRIPTION
Node.js v14 reached its end-of-life on April 30, 2023.

Reference:
- https://github.com/nodejs/Release